### PR TITLE
Update `docker-compose.yml` format and dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,17 @@
-retroboard:
-  build: .
-  links:
-    - redis
-    - mongo
-  ports:
-    - 32323:80
-redis:
-  image: redis:3.0.0
-mongo:
-  image: mongo:3.0.2
+---
+version: "2"
+services:
+  retroboard:
+    build: .
+    depends_on:
+      - redis
+      - mongo
+    ports:
+      - 32323:80
+    environment:
+      REDIS_URI: redis://redis:6379
+      MONGO_URI: mongodb://mongo/retroboard
+  redis:
+    image: redis:3.2
+  mongo:
+    image: mongo:3.2

--- a/src/clj/retroboard/util.clj
+++ b/src/clj/retroboard/util.clj
@@ -51,17 +51,10 @@
         (handler req*))
       (handler req))))
 
-(defn mongo-uri [] (if (System/getenv "MONGO_PORT_27017_TCP_ADDR")
-                     (str "mongodb://"
-                          (System/getenv "MONGO_PORT_27017_TCP_ADDR")
-                          ":"
-                          (System/getenv "MONGO_PORT_27017_TCP_PORT")
-                          "/remboard")
-                     "mongodb://127.0.0.1/retroboard"))
+(defn mongo-uri []
+  (or (System/getenv "MONGO_URI")
+      "mongodb://localhost/retroboard"))
 
-(defn redis-uri [] (if (System/getenv "REDIS_PORT_6379_TCP_ADDR")
-                     (str "redis://"
-                          (System/getenv "REDIS_PORT_6379_TCP_ADDR")
-                          ":"
-                          (System/getenv "REDIS_PORT_6379_TCP_PORT"))
-                     "redis://127.0.0.1:6379"))
+(defn redis-uri []
+  (or (System/getenv "REDIS_URI")
+      "redis://localhost:6379"))


### PR DESCRIPTION
Redis and MongoDB are conservatively updated to versions that came up on a Debian machine.

The default connection specs for MongoDB and Redis have been updated to work with `depends_on` instead of `links`, which is now a legacy Docker feature.